### PR TITLE
generate.py: fix "-l" prefixed lib names

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -13,7 +13,7 @@ def get_OS():
         return 'linux'
 
     if sys.platform == 'win32':
-        return 'win32'
+        return 'win'
 
 generator_default_variables = {
     'OS': get_OS(),

--- a/generate.py
+++ b/generate.py
@@ -94,6 +94,17 @@ def get_flags_factories(platform, target):
 
     return generic_flags_factories()
 
+def get_defines_factories(platform, target):
+    def get_defines(config, config_target):
+        defines = config_target.get('defines', [])
+        extra_defines= []
+        if platform  == "Windows":
+            if config in CONFIGURATIONS:
+                msvs_settings = gyp.msvs_emulation.MsvsSettings(target, {})
+                extra_defines = msvs_settings.GetComputedDefines(config)
+        return defines + extra_defines
+    return get_defines
+
 class Writer(object):
     def __init__(self, file):
         self._file         = file
@@ -389,7 +400,7 @@ def generate_target(platform, name, target, analysis, all_targets):
                 generate_config_properties(writer,
                                            '{}-{}'.format(unqualified_name, category),
                                            target,
-                                           lambda _, target: target.get('defines', []),
+                                           get_defines_factories(platform, target),
                                            'target_compile_definitions',
                                            True)
 


### PR DESCRIPTION
It is valid for gyp to prefix a library name with "`-l`", for example,
`-lgdi32`. However, for cmake, we need to strip the "`-l`" part.